### PR TITLE
fix: DataForm Json examples were not webpackable

### DIFF
--- a/sdk/webpack.config.js
+++ b/sdk/webpack.config.js
@@ -94,6 +94,8 @@ module.exports = env => {
                 { from: "**/*.jpg" },
                 { from: "**/*.png" },
                 { from: "**/*.xml" },
+                { from: "**/person-model.json" },
+                { from: "**/person-metadata.json" },
             ]),
             // Generate a bundle starter script and activate it in package.json
             new nsWebpack.GenerateBundleStarterPlugin([


### PR DESCRIPTION
To reproduce:
```
tns run ios --bundle
```

navigate to DataForm/Getting started JSON - it is emply